### PR TITLE
attempt to fix/lessen some problems mentioned in issue #9

### DIFF
--- a/has/haslength.go
+++ b/has/haslength.go
@@ -5,13 +5,27 @@ import (
 	"github.com/corbym/gocrest"
 )
 
-// Length can be called with arrays and strings
+const description = "value with length %v"
+
+// Length can be called with arrays
 // Returns a matcher that matches if the length matches the given criteria
-func Length[V any, A []V | string](expected int) *gocrest.Matcher[A] {
-	const description = "value with length %v"
-	matcher := new(gocrest.Matcher[A])
+func Length[T any](expected int) *gocrest.Matcher[[]T] {
+	matcher := new(gocrest.Matcher[[]T])
 	matcher.Describe = fmt.Sprintf(description, expected)
-	matcher.Matches = func(actual A) bool {
+	matcher.Matches = func(actual []T) bool {
+		lenOfActual := len(actual)
+		matcher.Actual = fmt.Sprintf("length was %d", lenOfActual)
+		return lenOfActual == expected
+	}
+	return matcher
+}
+
+// StringLength can be called with strings
+// Returns a matcher that matches if the length matches the given criteria
+func StringLength(expected int) *gocrest.Matcher[string] {
+	matcher := new(gocrest.Matcher[string])
+	matcher.Describe = fmt.Sprintf(description, expected)
+	matcher.Matches = func(actual string) bool {
 		lenOfActual := len(actual)
 		matcher.Actual = fmt.Sprintf("length was %d", lenOfActual)
 		return lenOfActual == expected
@@ -22,7 +36,6 @@ func Length[V any, A []V | string](expected int) *gocrest.Matcher[A] {
 // MapLength can be called with maps
 // Returns a matcher that matches if the length matches the given criteria
 func MapLength[K comparable, V any](expected int) *gocrest.Matcher[map[K]V] {
-	const description = "value with length %v"
 	matcher := new(gocrest.Matcher[map[K]V])
 	matcher.Describe = fmt.Sprintf(description, expected)
 	matcher.Matches = func(actual map[K]V) bool {
@@ -33,13 +46,26 @@ func MapLength[K comparable, V any](expected int) *gocrest.Matcher[map[K]V] {
 	return matcher
 }
 
-// LengthMatching can be called with arrays or strings
+// LengthMatching can be called with arrays
 // Returns a matcher that matches if the length matches matcher passed in
-func LengthMatching[V any, A []V | string](expected *gocrest.Matcher[int]) *gocrest.Matcher[A] {
-	const description = "value with length %v"
-	matcher := new(gocrest.Matcher[A])
+func LengthMatching[A any](expected *gocrest.Matcher[int]) *gocrest.Matcher[[]A] {
+	matcher := new(gocrest.Matcher[[]A])
 	matcher.Describe = fmt.Sprintf(description, expected)
-	matcher.Matches = func(actual A) bool {
+	matcher.Matches = func(actual []A) bool {
+		lenOfActual := len(actual)
+		matcher.Actual = fmt.Sprintf("length was %d", lenOfActual)
+		return expected.Matches(lenOfActual)
+
+	}
+	return matcher
+}
+
+// StringLengthMatching can be called with arrays or strings
+// Returns a matcher that matches if the length matches matcher passed in
+func StringLengthMatching(expected *gocrest.Matcher[int]) *gocrest.Matcher[string] {
+	matcher := new(gocrest.Matcher[string])
+	matcher.Describe = fmt.Sprintf(description, expected)
+	matcher.Matches = func(actual string) bool {
 		lenOfActual := len(actual)
 		matcher.Actual = fmt.Sprintf("length was %d", lenOfActual)
 		return expected.Matches(lenOfActual)
@@ -51,7 +77,6 @@ func LengthMatching[V any, A []V | string](expected *gocrest.Matcher[int]) *gocr
 // MapLengthMatching can be called with maps
 // Returns a matcher that matches if the length matches the given matcher
 func MapLengthMatching[K comparable, V any](expected *gocrest.Matcher[int]) *gocrest.Matcher[map[K]V] {
-	const description = "value with length %v"
 	matcher := new(gocrest.Matcher[map[K]V])
 	matcher.Describe = fmt.Sprintf(description, expected)
 	matcher.Matches = func(actual map[K]V) bool {

--- a/has/hasstructvalues.go
+++ b/has/hasstructvalues.go
@@ -13,8 +13,8 @@ type StructMatchers[A any] map[string]*gocrest.Matcher[A]
 // This method can be used to check single struct fields in different ways or omit checking some struct fields at all.
 // Will automatically de-reference pointers.
 // Panics if the actual value is not a struct.
-// Panics if Structmatchers contains a key that can not be found in the actual struct.
-// Panics if Structmatchers contains a key that is unexported.
+// Panics if StructMatchers contains a key that can not be found in the actual struct.
+// Panics if StructMatchers contains a key that is unexported.
 func StructWithValues[A any, B any](expects StructMatchers[B]) *gocrest.Matcher[A] {
 	match := new(gocrest.Matcher[A])
 	match.Describe = fmt.Sprintf("struct values to match {%s}", describeStructMatchers(expects))

--- a/is/contains.go
+++ b/is/contains.go
@@ -143,7 +143,7 @@ func listContains[T comparable, A []T](expected A, actualValue A) bool {
 	return len(contains) == len(expected)
 }
 func listMatches[T comparable](expected []*gocrest.Matcher[T], actualValue []T) bool {
-	contains := make(map[interface{}]bool)
+	contains := make(map[T]bool)
 	for i := 0; i < len(expected); i++ {
 		for y := 0; y < len(actualValue); y++ {
 			exp := expected[i]

--- a/is/contains.go
+++ b/is/contains.go
@@ -7,7 +7,7 @@ import (
 )
 
 // StringContaining finds if all x's are contained as value in y.
-// Acts like "ContainsAll", all elements given must be present (or must match) in actual in the same order as the expected values.
+// Acts like "ContainsAll", all elements given must be present.
 func StringContaining(expected ...string) *gocrest.Matcher[string] {
 	match := new(gocrest.Matcher[string])
 	match.Describe = fmt.Sprintf("something that contains %v", expected)

--- a/is/empty.go
+++ b/is/empty.go
@@ -4,13 +4,34 @@ import (
 	"github.com/corbym/gocrest"
 )
 
-// Empty matches if the actual is "empty".
-// 'string' values are empty if they are "", maps, arrays and slices are empty if len(actual) is 0.
+// Empty matches if the actual array or slice is len(actual) is 0.
 // Returns a matcher that evaluates true if actual is "empty".
-func Empty[K comparable, T any, A string | []T | map[K]T]() *gocrest.Matcher[A] {
-	matcher := new(gocrest.Matcher[A])
+func Empty[A any]() *gocrest.Matcher[[]A] {
+	matcher := new(gocrest.Matcher[[]A])
 	matcher.Describe = "empty value"
-	matcher.Matches = func(actual A) bool {
+	matcher.Matches = func(actual []A) bool {
+		return len(actual) == 0
+	}
+	return matcher
+}
+
+// EmptyString matches if the actual string if they are "" (==len(0))
+// Returns a matcher that evaluates true if actual is "empty".
+func EmptyString() *gocrest.Matcher[string] {
+	matcher := new(gocrest.Matcher[string])
+	matcher.Describe = "empty value"
+	matcher.Matches = func(actual string) bool {
+		return len(actual) == 0
+	}
+	return matcher
+}
+
+// EmptyMap matches if the actual maps if len(actual) is 0.
+// Returns a matcher that evaluates true if actual is "empty".
+func EmptyMap[K comparable, V any]() *gocrest.Matcher[map[K]V] {
+	matcher := new(gocrest.Matcher[map[K]V])
+	matcher.Describe = "empty value"
+	matcher.Matches = func(actual map[K]V) bool {
 		return len(actual) == 0
 	}
 	return matcher

--- a/is/greaterthan.go
+++ b/is/greaterthan.go
@@ -5,10 +5,14 @@ import (
 	"github.com/corbym/gocrest"
 )
 
+type Comparable interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~float32 | ~float64 | ~uint | ~uint16 | ~uint32 | ~uint64 | ~string
+}
+
 // GreaterThan matcher compares two values that are numeric or string values, and when
 // called returns true if actual > expected. Strings are compared lexicographically with '>'.
 // Returns a matcher that checks if actual is greater than expected.
-func GreaterThan[A int | int8 | int16 | int32 | int64 | float32 | float64 | uint | uint16 | uint32 | uint64 | string](expected A) *gocrest.Matcher[A] {
+func GreaterThan[A Comparable](expected A) *gocrest.Matcher[A] {
 	matcher := new(gocrest.Matcher[A])
 	matcher.Describe = fmt.Sprintf("value greater than <%v>", expected)
 	matcher.Matches = func(actual A) bool {

--- a/is/greaterthanorequalto.go
+++ b/is/greaterthanorequalto.go
@@ -4,7 +4,7 @@ import "github.com/corbym/gocrest"
 
 // GreaterThanOrEqualTo is a shorthand matcher for anyOf(greaterThan(x), equalTo(x))
 // Returns a matcher matching if actual >= expected (using deepEquals).
-func GreaterThanOrEqualTo[A int | int8 | int16 | int32 | int64 | float32 | float64 | uint | uint16 | uint32 | uint64 | string](expected A) *gocrest.Matcher[A] {
+func GreaterThanOrEqualTo[A Comparable](expected A) *gocrest.Matcher[A] {
 	matcher := new(gocrest.Matcher[A])
 	matcher.Matches = func(actual A) bool {
 		anyOf := AnyOf(GreaterThan(expected), EqualTo(expected))

--- a/is/lessthan.go
+++ b/is/lessthan.go
@@ -8,7 +8,7 @@ import (
 // LessThan matcher compares two values that are numeric or string values, and when
 // called returns true if actual < expected. Strings are compared lexicographically with '<'.
 // Returns a matcher that checks if actual is greater than expected.
-func LessThan[A int | int8 | int16 | int32 | int64 | float32 | float64 | uint | uint16 | uint32 | uint64 | string](expected A) *gocrest.Matcher[A] {
+func LessThan[A Comparable](expected A) *gocrest.Matcher[A] {
 	matcher := new(gocrest.Matcher[A])
 	matcher.Describe = fmt.Sprintf("value less than <%v>", expected)
 	matcher.Matches = func(actual A) bool {

--- a/is/lessthanorequalto.go
+++ b/is/lessthanorequalto.go
@@ -4,7 +4,7 @@ import "github.com/corbym/gocrest"
 
 // LessThanOrEqualTo is a short hand matcher for anyOf(lessThan(x), equalTo(x))
 // Returns a matcher matching if actual <= expected (using deepEquals).
-func LessThanOrEqualTo[A int | int8 | int16 | int32 | int64 | float32 | float64 | uint | uint16 | uint32 | uint64 | string](expected A) *gocrest.Matcher[A] {
+func LessThanOrEqualTo[A Comparable](expected A) *gocrest.Matcher[A] {
 	matcher := new(gocrest.Matcher[A])
 	matcher.Matches = func(actual A) bool {
 		anyOf := AnyOf(LessThan(expected), EqualTo(expected))

--- a/is/nil.go
+++ b/is/nil.go
@@ -7,7 +7,7 @@ import (
 
 var description = "value that is <nil>"
 
-// Nil matches if the actual value is nil
+// Nil matches if the actual error value is nil
 func Nil() *gocrest.Matcher[error] {
 	match := new(gocrest.Matcher[error])
 	match.Describe = description
@@ -17,6 +17,8 @@ func Nil() *gocrest.Matcher[error] {
 	}
 	return match
 }
+
+// NilArray matches if the actual array value is nil
 func NilArray[A any]() *gocrest.Matcher[[]A] {
 	match := new(gocrest.Matcher[[]A])
 	match.Describe = description
@@ -26,6 +28,8 @@ func NilArray[A any]() *gocrest.Matcher[[]A] {
 	}
 	return match
 }
+
+// NilMap matches if the actual map value is nil
 func NilMap[K comparable, V any]() *gocrest.Matcher[map[K]V] {
 	match := new(gocrest.Matcher[map[K]V])
 	match.Describe = description
@@ -35,6 +39,8 @@ func NilMap[K comparable, V any]() *gocrest.Matcher[map[K]V] {
 	}
 	return match
 }
+
+// NilPtr matches if the actual pointer to T is nil
 func NilPtr[T any]() *gocrest.Matcher[*T] {
 	match := new(gocrest.Matcher[*T])
 	match.Describe = description

--- a/is/nil.go
+++ b/is/nil.go
@@ -3,23 +3,44 @@ package is
 import (
 	"fmt"
 	"github.com/corbym/gocrest"
-	"reflect"
 )
 
+var description = "value that is <nil>"
+
 // Nil matches if the actual value is nil
-func Nil[A any]() *gocrest.Matcher[A] {
-	match := new(gocrest.Matcher[A])
-	match.Describe = "value that is <nil>"
-	match.Matches = func(actual A) bool {
+func Nil() *gocrest.Matcher[error] {
+	match := new(gocrest.Matcher[error])
+	match.Describe = description
+	match.Matches = func(actual error) bool {
 		match.Actual = fmt.Sprintf("%v", actual)
-		if any(actual) == nil {
-			return true
-		}
-		switch reflect.TypeOf(actual).Kind() {
-		case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
-			return reflect.ValueOf(actual).IsNil()
-		}
-		return false // anything else is never nil (hopefully)
+		return actual == nil
+	}
+	return match
+}
+func NilArray[A any]() *gocrest.Matcher[[]A] {
+	match := new(gocrest.Matcher[[]A])
+	match.Describe = description
+	match.Matches = func(actual []A) bool {
+		match.Actual = fmt.Sprintf("%v", actual)
+		return actual == nil
+	}
+	return match
+}
+func NilMap[K comparable, V any]() *gocrest.Matcher[map[K]V] {
+	match := new(gocrest.Matcher[map[K]V])
+	match.Describe = description
+	match.Matches = func(actual map[K]V) bool {
+		match.Actual = fmt.Sprintf("%v", actual)
+		return actual == nil
+	}
+	return match
+}
+func NilPtr[T any]() *gocrest.Matcher[*T] {
+	match := new(gocrest.Matcher[*T])
+	match.Describe = description
+	match.Matches = func(actual *T) bool {
+		match.Actual = fmt.Sprintf("%v", actual)
+		return actual == nil
 	}
 	return match
 }

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1160,7 +1160,7 @@ func TestCallingFunctionEventually(t *testing.T) {
 		return a
 	}
 	then.WithinFiveSeconds(t, func(eventually gocrest.TestingT) {
-		then.AssertThat(eventually, by.Calling[string, string](function, "hi"), is.EqualTo("hi"))
+		then.AssertThat(eventually, by.Calling(function, "hi"), is.EqualTo("hi"))
 	})
 }
 func firstTestChannel() chan int {

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -180,7 +180,7 @@ func TestEmptyStringIsEmptyPasses(testing *testing.T) {
 	}
 	for _, test := range equalsItems {
 		stubTestingT := new(StubTestingT)
-		then.AssertThat(stubTestingT, test.actual, is.Empty[string, string, string]())
+		then.AssertThat(stubTestingT, test.actual, is.EmptyString())
 		if stubTestingT.HasFailed() != test.shouldFail {
 			testing.Errorf("assertThat(%v, Empty()) gave unexpected test result (wanted failed %v, got failed %v)", test.actual, test.shouldFail, stubTestingT.HasFailed())
 		}
@@ -196,9 +196,9 @@ func TestEmptyMapIsEmptyPasses(testing *testing.T) {
 	}
 	for _, test := range equalsItems {
 		stubTestingT := new(StubTestingT)
-		then.AssertThat(stubTestingT, test.actual, is.Empty[string, bool, map[string]bool]())
+		then.AssertThat(stubTestingT, test.actual, is.EmptyMap[string, bool]())
 		if stubTestingT.HasFailed() != test.shouldFail {
-			testing.Errorf("assertThat(%v, Empty()) gave unexpected test result (wanted failed %v, got failed %v)", test.actual, test.shouldFail, stubTestingT.HasFailed())
+			testing.Errorf("assertThat(%v, EmptyMap()) gave unexpected test result (wanted failed %v, got failed %v)", test.actual, test.shouldFail, stubTestingT.HasFailed())
 		}
 	}
 }
@@ -212,7 +212,7 @@ func TestEmptyArrayIsEmptyPasses(testing *testing.T) {
 	}
 	for _, test := range equalsItems {
 		stubTestingT := new(StubTestingT)
-		then.AssertThat(stubTestingT, test.actual, is.Empty[string, string, []string]())
+		then.AssertThat(stubTestingT, test.actual, is.Empty[string]())
 		if stubTestingT.HasFailed() != test.shouldFail {
 			testing.Errorf("assertThat(%v, Empty()) gave unexpected test result (wanted failed %v, got failed %v)", test.actual, test.shouldFail, stubTestingT.HasFailed())
 		}
@@ -791,7 +791,7 @@ func TestSizeMapMatcherDescription(t *testing.T) {
 		matcher     *gocrest.Matcher[map[string]bool]
 		expected    string
 	}{
-		{description: "Empty", actual: map[string]bool{"foo": true}, matcher: is.Empty[string, bool, map[string]bool](), expected: "empty value"},
+		{description: "Empty", actual: map[string]bool{"foo": true}, matcher: is.EmptyMap[string, bool](), expected: "empty value"},
 		{description: "HasKey", actual: map[string]bool{"hi": true}, matcher: has.Key[string, bool]("foo"), expected: "map has key 'foo'"},
 		{description: "HasKeys", actual: map[string]bool{"hi": true, "bye": false}, matcher: has.AllKeys[string, bool]("hi", "foo"), expected: "map has keys '[hi foo]'"},
 	}
@@ -856,7 +856,7 @@ func TestAllOfDescribesOnlyMismatches(testing *testing.T) {
 	then.AssertThat(stubTestingT, "abc", is.AllOf(
 		is.EqualTo("abc"),
 		is.StringContaining("e", "f"),
-		is.Empty[string, string, string](),
+		is.EmptyString(),
 	))
 	if !strings.Contains(stubTestingT.MockTestOutput, "Expected: something that contains [e f] and empty value\n") {
 		testing.Errorf("incorrect description:%s", stubTestingT.MockTestOutput)
@@ -1040,7 +1040,7 @@ func TestStructValues(t *testing.T) {
 				Id string
 			}{},
 			expected: has.StructMatchers[string]{
-				"Id": is.Empty[string, string, string](),
+				"Id": is.EmptyString(),
 			},
 			shouldFail: false,
 		},


### PR DESCRIPTION
Splits up the Length, Empty and Nil matchers.

Unfortunately, for matchers that work on arrays, maps or pointers will still require the compiler to be told the type of the underlying value. 
E.g. 
```go
// nil pointer, actual is declared as `*string`
then.AssertThat(testing, values.actual, is.NilPtr[string]())
//[]int actual 
then.AssertThat(stubTestingT, test.actual, has.Length[int](test.expected))
// map
then.AssertThat(t, map[string]bool{"hello": true}, has.MapLength[string, bool](1))
```
.. but vanilla `Nil` only works on errors and requires no boilerplate types:
```go
then.AssertThat(stubTestingT, someError, is.Nil())
```
.. would this be more acceptable [nitram509](https://github.com/nitram509)?
fixes #9

